### PR TITLE
Removed dependency to gcc-4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if (UNIX)
     list(APPEND CUDA_NVCC_FLAGS "-arch=sm_20;--compiler-options;-O2;-DVERBOSE") 
   else()
     set(EXTRA_CXX_FLAGS "-DVERBOSE -msse2 -std=c++0x ")
-    list(APPEND CUDA_NVCC_FLAGS "-arch=sm_20;--compiler-bindir=/usr/bin/gcc-4.4;--compiler-options;-O2;-DVERBOSE") 
+    list(APPEND CUDA_NVCC_FLAGS "-arch=sm_20;--compiler-options;-O2;-DVERBOSE") 
   endif()
 endif()
 


### PR DESCRIPTION
this was causing an immediate compiler error since most modern systems do not have gcc-4.4 and no need to specify a gcc version.

it build fine on my machine without it.
