### PR TITLE
Fixed a few compiler errors

### DIFF
--- a/cudaSiftD.cu
+++ b/cudaSiftD.cu
@@ -2,7 +2,7 @@
 // CUDA SIFT extractor by Marten Bjorkman aka Celebrandil //
 //********************************************************//  
 
-#include <cudautils.h>
+#include "cudautils.h"
 #include "cudaSiftD.h"
 #include "cudaSift.h"
 

--- a/cudaSiftH.cu
+++ b/cudaSiftH.cu
@@ -6,7 +6,8 @@
 #include <cstring>
 #include <cmath>
 #include <iostream>
-#include <cudautils.h>
+#include <algorithm>
+#include "cudautils.h"
 
 #include "cudaImage.h"
 #include "cudaSift.h"


### PR DESCRIPTION
This PR fixes a few compiler errors in MSVC:
* "cudautils.h not found" in cudaSiftD.cu and in cudaSiftH.cu
* "std::min not declared" in cudaSiftH.cu