### PR TITLE
FIX: fixed ratio test in FindMaxCorr10

### DIFF
--- a/matching.cu
+++ b/matching.cu
@@ -387,6 +387,9 @@ __global__ void FindMaxCorr10(SiftPoint *sift1, SiftPoint *sift2, int numPts1, i
 	  index = indices[y*M7W + tx];
 	} else if (scores1[y*M7W + tx]>sec_score)
 	  sec_score = scores1[y*M7W + tx];
+
+        if (scores2[y*M7W + tx]>sec_score)
+          sec_score = scores2[y*M7W + tx];
       }
     sift1[bp1 + tx].score = max_score;
     sift1[bp1 + tx].match = index;


### PR DESCRIPTION
The fix ensures that the second best match is found correctly and thus the ratio test is performed as intended. Note that this change should be applied to other versions of FindMaxCorr as well, this commit changes the one currently used (FindMaxCorr10).