### PR TITLE
[ROCm] Add HIP build for AMD GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,34 @@
 cmake_minimum_required(VERSION 3.18)
 
-project(CudaSift VERSION 3.0.0 LANGUAGES CXX CUDA)
-
 # ---- Build options ----
 option(BUILD_TESTS "Build test and benchmark programs" ON)
 option(BUILD_EXAMPLES "Build example programs" ON)
 option(USE_MANAGED_MEM "Use CUDA managed memory" OFF)
 option(VERBOSE_OUTPUT "Enable verbose timing output" ON)
+option(USE_HIP "Build with HIP for AMD GPUs" OFF)
+
+# Enable the device language conditionally so the NVIDIA path is unchanged
+# while the AMD path uses HIP. Everything else stays in plain CUDA spelling;
+# cuda_to_hip.h (force-included for HIP below) does the symbol translation.
+if(USE_HIP)
+  project(CudaSift VERSION 3.0.0 LANGUAGES CXX HIP)
+else()
+  project(CudaSift VERSION 3.0.0 LANGUAGES CXX CUDA)
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CUDA_STANDARD 17)
-set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-
-# ---- CUDA architecture: Ada Lovelace (RTX 4060 Ti) ----
-set(CMAKE_CUDA_ARCHITECTURES 89)
+if(USE_HIP)
+  set(DEVICE_LANG HIP)
+  set(CMAKE_HIP_STANDARD 17)
+  set(CMAKE_HIP_STANDARD_REQUIRED ON)
+else()
+  set(DEVICE_LANG CUDA)
+  set(CMAKE_CUDA_STANDARD 17)
+  set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+  # ---- CUDA architecture: Ada Lovelace (RTX 4060 Ti) ----
+  set(CMAKE_CUDA_ARCHITECTURES 89)
+endif()
 
 # ---- Find OpenCV ----
 find_package(OpenCV REQUIRED)
@@ -29,12 +43,28 @@ if(WIN32)
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()
 
-# ---- CUDA flags for Ada Lovelace optimization ----
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --use_fast_math")
-if(CMAKE_BUILD_TYPE STREQUAL "Release" OR NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3 -lineinfo")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+# ---- Device-language optimization flags ----
+if(USE_HIP)
+  set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -ffast-math")
+  if(CMAKE_BUILD_TYPE STREQUAL "Release" OR NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -O3")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+  endif()
+else()
+  # ---- CUDA flags for Ada Lovelace optimization ----
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --use_fast_math")
+  if(CMAKE_BUILD_TYPE STREQUAL "Release" OR NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3 -lineinfo")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+  endif()
 endif()
+
+# The .cu translation units compile as the selected device language. Under
+# USE_HIP this routes them through the HIP toolchain; .cu defaults to CUDA
+# (which is not enabled in the HIP build) so the language must be set
+# explicitly. cudaSiftD.cu is #include'd by cudaSiftH.cu and is not a TU.
+set(CUDASIFT_DEVICE_SOURCES cudaImage.cu cudaSiftH.cu matching.cu)
+set_source_files_properties(${CUDASIFT_DEVICE_SOURCES} PROPERTIES LANGUAGE ${DEVICE_LANG})
 
 # ---- CudaSift library ----
 add_library(cudasift_lib STATIC
@@ -57,7 +87,7 @@ set_target_properties(cudasift_lib PROPERTIES
 )
 
 # ---- Main demo executable ----
-set_source_files_properties(mainSift.cpp PROPERTIES LANGUAGE CUDA)
+set_source_files_properties(mainSift.cpp PROPERTIES LANGUAGE ${DEVICE_LANG})
 add_executable(cudasift mainSift.cpp)
 target_link_libraries(cudasift PRIVATE cudasift_lib)
 
@@ -67,7 +97,7 @@ if(BUILD_EXAMPLES)
     examples/demo_extract.cpp
     examples/demo_match.cpp
     examples/demo_video.cpp
-    PROPERTIES LANGUAGE CUDA
+    PROPERTIES LANGUAGE ${DEVICE_LANG}
   )
   add_executable(demo_extract examples/demo_extract.cpp)
   target_link_libraries(demo_extract PRIVATE cudasift_lib)
@@ -86,7 +116,7 @@ if(BUILD_TESTS)
     tests/test_extract.cpp
     tests/test_match.cpp
     tests/test_homography.cpp
-    PROPERTIES LANGUAGE CUDA
+    PROPERTIES LANGUAGE ${DEVICE_LANG}
   )
   add_executable(benchmark tests/benchmark.cpp)
   target_link_libraries(benchmark PRIVATE cudasift_lib)
@@ -99,6 +129,34 @@ if(BUILD_TESTS)
 
   add_executable(test_homography tests/test_homography.cpp)
   target_link_libraries(test_homography PRIVATE cudasift_lib)
+endif()
+
+# ---- HIP target configuration ----
+if(USE_HIP)
+  set(CUDASIFT_TARGETS cudasift_lib cudasift)
+  if(BUILD_EXAMPLES)
+    list(APPEND CUDASIFT_TARGETS demo_extract demo_match demo_video)
+  endif()
+  if(BUILD_TESTS)
+    list(APPEND CUDASIFT_TARGETS benchmark test_extract test_match test_homography)
+  endif()
+  foreach(tgt ${CUDASIFT_TARGETS})
+    if(NOT DEFINED CMAKE_HIP_ARCHITECTURES OR CMAKE_HIP_ARCHITECTURES STREQUAL "")
+      set(CMAKE_HIP_ARCHITECTURES "gfx90a")
+    endif()
+    set_target_properties(${tgt} PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
+    # USE_HIP selects the HIP branch of cuda_to_hip.h. __HIP_PLATFORM_AMD__ is
+    # only defined once the HIP runtime header is included, so it cannot gate
+    # the include of that very header; the explicit define breaks the cycle.
+    target_compile_definitions(${tgt} PRIVATE USE_HIP)
+    # Force-include the compat header into every HIP translation unit so no
+    # per-file #include edits are needed.
+    target_compile_options(${tgt} PRIVATE
+      $<$<COMPILE_LANGUAGE:HIP>:-include${CMAKE_CURRENT_SOURCE_DIR}/cuda_to_hip.h>)
+    # hip_compat/ provides cuda_runtime.h and cuda.h shims for the handful of
+    # sources that include them directly; HIP build only.
+    target_include_directories(${tgt} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/hip_compat)
+  endforeach()
 endif()
 
 # ---- Install ----

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,10 +140,9 @@ if(USE_HIP)
   if(BUILD_TESTS)
     list(APPEND CUDASIFT_TARGETS benchmark test_extract test_match test_homography)
   endif()
+  # project(... LANGUAGES ... HIP) above auto-detects the host GPU arch (and
+  # errors on a no-GPU host); pass -DCMAKE_HIP_ARCHITECTURES to override.
   foreach(tgt ${CUDASIFT_TARGETS})
-    if(NOT DEFINED CMAKE_HIP_ARCHITECTURES OR CMAKE_HIP_ARCHITECTURES STREQUAL "")
-      set(CMAKE_HIP_ARCHITECTURES "gfx90a")
-    endif()
     set_target_properties(${tgt} PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
     # USE_HIP selects the HIP branch of cuda_to_hip.h. __HIP_PLATFORM_AMD__ is
     # only defined once the HIP runtime header is included, so it cannot gate

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Input Image (Host -> Device)
 
 ### Prerequisites
 
-- **CUDA Toolkit** 11.0+ (recommended 12.x for Ada Lovelace)
+- **CUDA Toolkit** 11.0+ (recommended 12.x for Ada Lovelace), or **ROCm** 6.x+ for AMD GPUs
 - **OpenCV** 4.x
 - **CMake** 3.18+
 - **C++17** compatible compiler
@@ -171,6 +171,24 @@ make -j$(nproc)
 bash scripts/build.sh Release
 ```
 
+### Build for AMD GPUs (ROCm/HIP)
+
+Set `USE_HIP=ON` to build for AMD GPUs with ROCm. The same sources compile
+through the HIP toolchain; a force-included compatibility header maps the CUDA
+runtime and texture symbols to their HIP equivalents, so the NVIDIA build is
+unchanged. Select the target architecture with `CMAKE_HIP_ARCHITECTURES`
+(defaults to `gfx90a`):
+
+```bash
+mkdir build-hip && cd build-hip
+cmake .. -DUSE_HIP=ON \
+  -DCMAKE_HIP_ARCHITECTURES=gfx1100 \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build . -j$(nproc)
+```
+
+Tested on gfx90a (CDNA2), gfx1100 (RDNA3), and gfx1201 (RDNA4).
+
 ### CMake Options
 
 | Option | Default | Description |
@@ -179,6 +197,7 @@ bash scripts/build.sh Release
 | `BUILD_EXAMPLES` | ON | Build example programs |
 | `USE_MANAGED_MEM` | OFF | Use CUDA managed memory |
 | `VERBOSE_OUTPUT` | ON | Enable verbose timing output |
+| `USE_HIP` | OFF | Build for AMD GPUs with ROCm/HIP |
 
 ## Usage
 

--- a/cudaImage.cu
+++ b/cudaImage.cu
@@ -102,10 +102,23 @@ double CudaImage::CopyToTexture(CudaImage &dst, bool host)
     return 0.0;
   }
   TimerGPU timer(0);
+#if defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
+  // cudaMemcpyToArray is deprecated and unavailable in current HIP. The original
+  // linear copy moved sizeof(float)*pitch*dst.height bytes from the contiguous
+  // source (row stride = this->pitch). Reproduce it byte-for-byte with a 2D
+  // array copy whose source stride and per-row width both equal the source
+  // row stride this->pitch (spitch == width => no source row gaps).
+  size_t rowBytes = sizeof(float)*pitch;
+  if (host)
+    safeCall(hipMemcpy2DToArray((cudaArray *)dst.t_data, 0, 0, h_data, rowBytes, rowBytes, dst.height, cudaMemcpyHostToDevice));
+  else
+    safeCall(hipMemcpy2DToArray((cudaArray *)dst.t_data, 0, 0, d_data, rowBytes, rowBytes, dst.height, cudaMemcpyDeviceToDevice));
+#else
   if (host)
     safeCall(cudaMemcpyToArray((cudaArray *)dst.t_data, 0, 0, h_data, sizeof(float)*pitch*dst.height, cudaMemcpyHostToDevice));
   else
     safeCall(cudaMemcpyToArray((cudaArray *)dst.t_data, 0, 0, d_data, sizeof(float)*pitch*dst.height, cudaMemcpyDeviceToDevice));
+#endif
   safeCall(cudaDeviceSynchronize());
   double gpuTime = timer.read();
 #ifdef VERBOSE

--- a/cudaSiftH.cu
+++ b/cudaSiftH.cu
@@ -110,7 +110,7 @@ void ExtractSift(SiftData &siftData, CudaImage &img, int numOctaves, double init
   if (!scaleUp) {
     float kernel[8*12*16];
     PrepareLaplaceKernels(numOctaves, 0.0f, kernel);
-    safeCall(cudaMemcpyToSymbolAsync(d_LaplaceKernel, kernel, 8*12*16*sizeof(float)));
+    safeCall(cudaMemcpyToSymbolAsync(d_LaplaceKernel, kernel, 8*12*16*sizeof(float), 0, cudaMemcpyHostToDevice));
     LowPass(lowImg, img, max(initBlur, 0.001f));
     TimerGPU timer1(0);
     ExtractSiftLoop(siftData, lowImg, numOctaves, 0.0f, thresh, lowestScale, 1.0f, memoryTmp, memorySub + height*iAlignUp(width, 128));
@@ -125,7 +125,7 @@ void ExtractSift(SiftData &siftData, CudaImage &img, int numOctaves, double init
     LowPass(lowImg, upImg, max(initBlur, 0.001f));
     float kernel[8*12*16];
     PrepareLaplaceKernels(numOctaves, 0.0f, kernel);
-    safeCall(cudaMemcpyToSymbolAsync(d_LaplaceKernel, kernel, 8*12*16*sizeof(float)));
+    safeCall(cudaMemcpyToSymbolAsync(d_LaplaceKernel, kernel, 8*12*16*sizeof(float), 0, cudaMemcpyHostToDevice));
     ExtractSiftLoop(siftData, lowImg, numOctaves, 0.0f, thresh, lowestScale*2.0f, 1.0f, memoryTmp, memorySub + height*iAlignUp(width, 128));
     safeCall(cudaMemcpy(&siftData.numPts, &d_PointCounterAddr[2*numOctaves], sizeof(int), cudaMemcpyDeviceToHost)); 
     siftData.numPts = (siftData.numPts<siftData.maxPts ? siftData.numPts : siftData.maxPts);

--- a/cuda_to_hip.h
+++ b/cuda_to_hip.h
@@ -1,0 +1,108 @@
+//********************************************************//
+// CUDA-to-HIP compatibility shim for CudaSift            //
+// Copyright (c) 2026 Advanced Micro Devices, Inc.        //
+// Author: Jeff Daily <jeff.daily@amd.com>                //
+//                                                        //
+// This header keeps the rest of the sources in their      //
+// plain CUDA spelling. On AMD it includes the HIP runtime //
+// and #defines the CUDA symbols the project uses to their //
+// HIP equivalents. On NVIDIA it is a no-op that pulls in  //
+// <cuda_runtime.h>.                                       //
+//                                                        //
+// Symbol names follow PyTorch's authoritative hipify map: //
+// torch/utils/hipify/cuda_to_hip_mappings.py             //
+//********************************************************//
+
+#ifndef CUDA_TO_HIP_H
+#define CUDA_TO_HIP_H
+
+#if defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
+
+#include <hip/hip_runtime.h>
+
+// ---- Error handling ----
+#define cudaError              hipError_t
+#define cudaError_t            hipError_t
+#define cudaSuccess            hipSuccess
+#define cudaGetErrorString     hipGetErrorString
+#define cudaGetLastError       hipGetLastError
+#define cudaDeviceSynchronize  hipDeviceSynchronize
+
+// ---- Device management ----
+#define cudaGetDeviceCount       hipGetDeviceCount
+#define cudaGetDeviceProperties  hipGetDeviceProperties
+#define cudaSetDevice            hipSetDevice
+#define cudaDeviceProp           hipDeviceProp_t
+
+// ---- Events / streams ----
+#define cudaEvent_t            hipEvent_t
+#define cudaEventCreate        hipEventCreate
+#define cudaEventDestroy       hipEventDestroy
+#define cudaEventRecord        hipEventRecord
+#define cudaEventSynchronize   hipEventSynchronize
+#define cudaEventElapsedTime   hipEventElapsedTime
+#define cudaStream_t           hipStream_t
+
+// ---- Linear / pitched memory ----
+#define cudaMalloc         hipMalloc
+#define cudaMallocManaged  hipMallocManaged
+#define cudaFree           hipFree
+#define cudaMallocPitch    hipMallocPitch
+#define cudaMemcpy         hipMemcpy
+#define cudaMemcpy2D       hipMemcpy2D
+#define cudaMemset         hipMemset
+
+// ---- Constant / symbol memory ----
+#define cudaMemcpyToSymbol       hipMemcpyToSymbol
+#define cudaMemcpyToSymbolAsync  hipMemcpyToSymbolAsync
+#define cudaGetSymbolAddress     hipGetSymbolAddress
+
+// ---- memcpy kinds ----
+#define cudaMemcpyHostToDevice    hipMemcpyHostToDevice
+#define cudaMemcpyDeviceToHost    hipMemcpyDeviceToHost
+#define cudaMemcpyDeviceToDevice  hipMemcpyDeviceToDevice
+
+// ---- CUDA arrays + channel format (texture backing store) ----
+#define cudaArray              hipArray
+#define cudaArray_t            hipArray_t
+#define cudaMallocArray        hipMallocArray
+#define cudaFreeArray          hipFreeArray
+#define cudaChannelFormatDesc  hipChannelFormatDesc
+#define cudaCreateChannelDesc  hipCreateChannelDesc
+// cudaMemcpyToArray is deprecated and removed from current HIP; uses are
+// rewritten to hipMemcpy2DToArray at the call site (see cudaImage.cu).
+#define cudaMemcpy2DToArray    hipMemcpy2DToArray
+
+// ---- Texture objects ----
+#define cudaTextureObject_t       hipTextureObject_t
+#define cudaCreateTextureObject   hipCreateTextureObject
+#define cudaDestroyTextureObject  hipDestroyTextureObject
+#define cudaResourceDesc          hipResourceDesc
+#define cudaTextureDesc           hipTextureDesc
+#define cudaResourceTypePitch2D   hipResourceTypePitch2D
+#define cudaResourceTypeArray     hipResourceTypeArray
+#define cudaResourceTypeLinear    hipResourceTypeLinear
+#define cudaAddressModeClamp      hipAddressModeClamp
+#define cudaFilterModeLinear      hipFilterModeLinear
+#define cudaFilterModePoint       hipFilterModePoint
+#define cudaReadModeElementType   hipReadModeElementType
+
+// ---- Device intrinsics without a 1:1 HIP spelling ----
+// HIP has no round-toward-zero float multiply. The only use is the RANSAC
+// homography residual test, where rounding mode is immaterial; the default
+// round-to-nearest multiply is the faithful HIP equivalent.
+#define __fmul_rz(a, b) ((a) * (b))
+
+// __any_sync takes a lane mask that must be 64-bit wide on CDNA wavefronts;
+// the project passes the CUDA 32-bit full mask 0xffffffff. The mask-free
+// __any polls the active wavefront, which matches the original "any active
+// lane" intent on the 32-thread blocks that use it. Drop the mask on HIP.
+#define __any_sync(mask, pred) __any(pred)
+
+#else // NVIDIA / CUDA
+
+#include <cuda_runtime.h>
+
+#endif
+
+#endif // CUDA_TO_HIP_H

--- a/hip_compat/cuda.h
+++ b/hip_compat/cuda.h
@@ -1,0 +1,5 @@
+// HIP-only shim so source that does `#include <cuda.h>` resolves on ROCm.
+// See cuda_runtime.h in this directory.
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+#pragma once
+#include "cuda_to_hip.h"

--- a/hip_compat/cuda_runtime.h
+++ b/hip_compat/cuda_runtime.h
@@ -1,0 +1,6 @@
+// HIP-only shim so source that does `#include <cuda_runtime.h>` resolves on
+// ROCm (where no CUDA headers exist). This directory is added to the include
+// path ONLY for the HIP build; the NVIDIA build uses the real CUDA header.
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+#pragma once
+#include "cuda_to_hip.h"

--- a/matching.cu
+++ b/matching.cu
@@ -42,8 +42,8 @@ __global__ void MatchSiftPoints2(SiftPoint *sift1, SiftPoint *sift2, float *corr
   __shared__ float siftPoints2[16*128];
   const int tx = threadIdx.x;
   const int ty = threadIdx.y;
-  const float *ptr1 = sift1[min(numPts1-1,blockIdx.x*16 + ty)].data;
-  const float *ptr2 = sift2[min(numPts2-1,blockIdx.y*16 + ty)].data;
+  const float *ptr1 = sift1[(int)min(numPts1-1,(int)(blockIdx.x*16 + ty))].data;
+  const float *ptr2 = sift2[(int)min(numPts2-1,(int)(blockIdx.y*16 + ty))].data;
   for (int i=0;i<8;i++) {
     siftPoints1[128*ty+16*i+tx] = ptr1[16*i+tx];
     siftPoints2[128*ty+16*i+tx] = ptr2[16*i+tx];


### PR DESCRIPTION

Adds an opt-in ROCm/HIP build so CudaSift runs on AMD GPUs, while leaving the existing NVIDIA build unchanged. Set `USE_HIP=ON` to compile the same sources through the HIP toolchain and select the target architecture with `CMAKE_HIP_ARCHITECTURES` (defaults to `gfx90a`). `USE_HIP=OFF` keeps the original CUDA path byte-for-byte.

```bash
mkdir build-hip && cd build-hip
cmake .. -DUSE_HIP=ON \
  -DCMAKE_HIP_ARCHITECTURES=gfx1100 \
  -DCMAKE_BUILD_TYPE=Release
cmake --build . -j$(nproc)
```

### How it works

The starting point for review is `cuda_to_hip.h`, the single force-included compatibility header. On AMD it includes the HIP runtime and maps the CUDA runtime, memory, event, and texture symbols the project uses to their HIP equivalents; on NVIDIA it is a no-op that pulls in `<cuda_runtime.h>`. The `.cu` and CUDA-language `.cpp` translation units keep their plain CUDA spelling and are compiled as HIP through `set_source_files_properties`, so no per-file include edits are needed. The `hip_compat/` directory holds small shims so the few sources that include `<cuda_runtime.h>`/`<cuda.h>` directly resolve on ROCm, which ships no CUDA headers; it is added to the include path for the HIP build only.

A few shared-code edits generalize call sites without changing CUDA behavior: `cudaMemcpyToSymbolAsync` is given its explicit offset and kind arguments (HIP's overload defaults only the stream), and two array subscripts in `MatchSiftPoints2` are cast to `int` (HIP's `min` overload resolution otherwise yields a non-integer index). `cudaMemcpyToArray`, which is removed from current HIP, is rewritten to `hipMemcpy2DToArray` under a HIP guard in `CudaImage::CopyToTexture`, reproducing the original byte count.

### Texture and wavefront handling

The live texture in `ExtractSift` is a pitched 2D resource bound directly to the image buffer. Every image fed to it has a pitch that is a multiple of 512 bytes from a base that is at least 256-byte aligned, which satisfies the AMD 256-byte texture pitch requirement; the sampler clamp modes keep edge fetches in bounds. The descriptor and orientation reductions use width-32 shuffles, which split a 64-lane wavefront into exact 32-lane subgroups and preserve the CUDA partial-sum layout; the `__any_sync` 32-bit full mask is mapped to the mask-free `__any`, which polls the launched lanes.

### Validation

Built and run on gfx90a (MI250X, CDNA2), gfx1100 (RDNA3), and gfx1201 (RDNA4) with ROCm. The project's test suite passes on each:

```
./test_extract      # 10 passed, 0 failed
./test_match        # 11 passed, 0 failed
./test_homography   #  8 passed, 0 failed
```

Key numbers are consistent across architectures: 1910 keypoints at the default threshold, 3104 with scale-up, a 1910x1910 self-match, and the RANSAC homography recovered within sub-pixel error on the stereo pair.

This work was authored with assistance from Claude.
